### PR TITLE
Add all-in-one tool wrappers for grep, sed, bash, and cat

### DIFF
--- a/bash.go
+++ b/bash.go
@@ -1,0 +1,73 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/shaharia-lab/goai/mcp"
+	"github.com/shaharia-lab/goai/observability"
+	"os/exec"
+)
+
+const BashToolName = "bash_all_in_one"
+
+// Bash represents a wrapper around the system's bash command-line tool
+type Bash struct {
+	logger      observability.Logger
+	cmdExecutor CommandExecutor
+}
+
+// NewBash creates a new instance of the Bash wrapper
+func NewBash(logger observability.Logger) *Bash {
+	return &Bash{
+		logger:      logger,
+		cmdExecutor: &RealCommandExecutor{},
+	}
+}
+
+// BashAllInOneTool returns a mcp.Tool that can execute bash commands
+func (b *Bash) BashAllInOneTool() mcp.Tool {
+	return mcp.Tool{
+		Name:        BashToolName,
+		Description: "Execute bash commands with specified script or command",
+		InputSchema: json.RawMessage(`{
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Bash command or script to execute"
+                },
+                "args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Additional arguments for the command"
+                }
+            },
+            "required": ["command"]
+        }`),
+		Handler: func(ctx context.Context, params mcp.CallToolParams) (mcp.CallToolResult, error) {
+			var input struct {
+				Command string   `json:"command"`
+				Args    []string `json:"args"`
+			}
+
+			if err := json.Unmarshal(params.Arguments, &input); err != nil {
+				return mcp.CallToolResult{}, fmt.Errorf("failed to parse input: %w", err)
+			}
+
+			b.logger.Info("Executing bash command", "command", input.Command, "args", input.Args)
+			cmd := exec.Command("bash", append([]string{"-c", input.Command}, input.Args...)...)
+			output, err := b.cmdExecutor.ExecuteCommand(ctx, cmd)
+			if err != nil {
+				return mcp.CallToolResult{}, fmt.Errorf("bash command failed: %w", err)
+			}
+
+			return mcp.CallToolResult{
+				Content: []mcp.ToolResultContent{{Type: "text", Text: string(output)}},
+				IsError: false,
+			}, nil
+		},
+	}
+}

--- a/cat.go
+++ b/cat.go
@@ -1,0 +1,82 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/shaharia-lab/goai/mcp"
+	"github.com/shaharia-lab/goai/observability"
+	"os/exec"
+)
+
+const CatToolName = "cat_all_in_one"
+
+// Cat represents a wrapper around the system's cat command-line tool
+type Cat struct {
+	logger      observability.Logger
+	cmdExecutor CommandExecutor
+}
+
+// NewCat creates a new instance of the Cat wrapper
+func NewCat(logger observability.Logger) *Cat {
+	return &Cat{
+		logger:      logger,
+		cmdExecutor: &RealCommandExecutor{},
+	}
+}
+
+// CatAllInOneTool returns a mcp.Tool that can execute cat commands
+func (c *Cat) CatAllInOneTool() mcp.Tool {
+	return mcp.Tool{
+		Name:        CatToolName,
+		Description: "Display contents of files",
+		InputSchema: json.RawMessage(`{
+            "type": "object",
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of files to read"
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Additional cat options (e.g., -n for line numbers)"
+                }
+            },
+            "required": ["files"]
+        }`),
+		Handler: func(ctx context.Context, params mcp.CallToolParams) (mcp.CallToolResult, error) {
+			var input struct {
+				Files   []string `json:"files"`
+				Options []string `json:"options"`
+			}
+
+			if err := json.Unmarshal(params.Arguments, &input); err != nil {
+				return mcp.CallToolResult{}, fmt.Errorf("failed to parse input: %w", err)
+			}
+
+			if len(input.Files) == 0 {
+				return mcp.CallToolResult{}, fmt.Errorf("at least one file must be specified")
+			}
+
+			args := append(input.Options, input.Files...)
+
+			c.logger.Info("Executing cat command", "files", input.Files, "options", input.Options)
+			cmd := exec.Command("cat", args...)
+			output, err := c.cmdExecutor.ExecuteCommand(ctx, cmd)
+			if err != nil {
+				return mcp.CallToolResult{}, fmt.Errorf("cat command failed: %w", err)
+			}
+
+			return mcp.CallToolResult{
+				Content: []mcp.ToolResultContent{{Type: "text", Text: string(output)}},
+				IsError: false,
+			}, nil
+		},
+	}
+}

--- a/grep.go
+++ b/grep.go
@@ -1,0 +1,177 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/shaharia-lab/goai/mcp"
+	"github.com/shaharia-lab/goai/observability"
+	"os/exec"
+)
+
+const GrepToolName = "grep_all_in_one"
+
+// Grep represents a wrapper around the system's grep command-line tool
+type Grep struct {
+	logger      observability.Logger
+	cmdExecutor CommandExecutor
+}
+
+// NewGrep creates and returns a new instance of the Grep wrapper
+func NewGrep(logger observability.Logger) *Grep {
+	return &Grep{
+		logger:      logger,
+		cmdExecutor: &RealCommandExecutor{},
+	}
+}
+
+// GrepAllInOneTool returns a mcp.Tool that can execute grep commands
+func (g *Grep) GrepAllInOneTool() mcp.Tool {
+	return mcp.Tool{
+		Name:        GrepToolName,
+		Description: "Execute grep commands with specified pattern and options",
+		InputSchema: json.RawMessage(`{
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Pattern to search for"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "File or directory path to search in"
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Additional grep options (e.g., -r for recursive, -i for case-insensitive)"
+                }
+            },
+            "required": ["pattern", "path"]
+        }`),
+		Handler: func(ctx context.Context, params mcp.CallToolParams) (mcp.CallToolResult, error) {
+			ctx, span := observability.StartSpan(ctx, fmt.Sprintf("%s.Handler", params.Name))
+			defer span.End()
+
+			var input struct {
+				Pattern string   `json:"pattern"`
+				Path    string   `json:"path"`
+				Options []string `json:"options"`
+			}
+
+			if err := json.Unmarshal(params.Arguments, &input); err != nil {
+				g.logger.WithFields(map[string]interface{}{
+					observability.ErrorLogField: err,
+					"raw_input":                 string(params.Arguments),
+				}).Error("Failed to unmarshal input parameters")
+				span.RecordError(err)
+				return mcp.CallToolResult{}, fmt.Errorf("failed to parse input: %w", err)
+			}
+
+			if err := validateGrepInput(input); err != nil {
+				g.logger.WithFields(map[string]interface{}{
+					observability.ErrorLogField: err,
+				}).Error("Input validation failed")
+				span.RecordError(err)
+				return mcp.CallToolResult{}, err
+			}
+
+			// Ensure recursive search is enabled if a directory is provided
+			hasRecursive := false
+			for _, opt := range input.Options {
+				if opt == "-r" || opt == "-R" {
+					hasRecursive = true
+					break
+				}
+			}
+			if !hasRecursive {
+				input.Options = append(input.Options, "-r")
+			}
+
+			args := append(input.Options, "-E")
+			args = append(args, input.Pattern, input.Path)
+			cmd := exec.Command("grep", args...)
+
+			// Execute the command using the executor
+			output, err := g.cmdExecutor.ExecuteCommand(ctx, cmd)
+
+			// Special handling for grep exit codes
+			if err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					// Exit code 1 means no matches found (not an error)
+					if exitError.ExitCode() == 1 {
+						return mcp.CallToolResult{
+							Content: []mcp.ToolResultContent{
+								{
+									Type: "text",
+									Text: "No matches found",
+								},
+							},
+							IsError: false,
+						}, nil
+					}
+					// Exit code 2 or others indicate real errors
+					errorMsg := string(exitError.Stderr)
+					if errorMsg == "" {
+						errorMsg = err.Error()
+					}
+
+					g.logger.WithFields(map[string]interface{}{
+						observability.ErrorLogField: err,
+						"command":                   "grep",
+						"args":                      args,
+						"exit_code":                 exitError.ExitCode(),
+						"stderr":                    errorMsg,
+					}).Error("Grep command execution failed")
+
+					return mcp.CallToolResult{
+						Content: []mcp.ToolResultContent{
+							{
+								Type: "text",
+								Text: fmt.Sprintf("Grep command failed (exit code %d): %s\nCommand: grep %v",
+									exitError.ExitCode(), errorMsg, args),
+							},
+						},
+						IsError: true,
+					}, nil
+				}
+				// Handle non-exit errors
+				return mcp.CallToolResult{
+					Content: []mcp.ToolResultContent{
+						{
+							Type: "text",
+							Text: fmt.Sprintf("Command execution error: %s", err.Error()),
+						},
+					},
+					IsError: true,
+				}, nil
+			}
+
+			return mcp.CallToolResult{
+				Content: []mcp.ToolResultContent{
+					{
+						Type: "text",
+						Text: string(output),
+					},
+				},
+				IsError: false,
+			}, nil
+		},
+	}
+}
+
+func validateGrepInput(input struct {
+	Pattern string   `json:"pattern"`
+	Path    string   `json:"path"`
+	Options []string `json:"options"`
+}) error {
+	if input.Pattern == "" {
+		return fmt.Errorf("pattern is required")
+	}
+	if input.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+	return nil
+}

--- a/sed.go
+++ b/sed.go
@@ -1,0 +1,132 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/shaharia-lab/goai/mcp"
+	"github.com/shaharia-lab/goai/observability"
+	"os/exec"
+)
+
+const SedToolName = "sed_all_in_one"
+
+// Sed represents a wrapper around the system's sed command-line tool
+type Sed struct {
+	logger      observability.Logger
+	cmdExecutor CommandExecutor
+}
+
+// NewSed creates a new instance of the Sed wrapper
+func NewSed(logger observability.Logger) *Sed {
+	return &Sed{
+		logger:      logger,
+		cmdExecutor: &RealCommandExecutor{},
+	}
+}
+
+// SedAllInOneTool returns a mcp.Tool that can execute sed commands
+// SedAllInOneTool returns a mcp.Tool that can execute sed commands
+func (s *Sed) SedAllInOneTool() mcp.Tool {
+	return mcp.Tool{
+		Name:        SedToolName,
+		Description: "Stream editor for filtering and transforming text",
+		InputSchema: json.RawMessage(`{
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "Sed expression/pattern to apply"
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Files to process"
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Additional sed options (e.g., -i for in-place editing)"
+                }
+            },
+            "required": ["expression"]
+        }`),
+		Handler: func(ctx context.Context, params mcp.CallToolParams) (mcp.CallToolResult, error) {
+			var input struct {
+				Expression string   `json:"expression"`
+				Files      []string `json:"files"`
+				Options    []string `json:"options"`
+			}
+
+			if err := json.Unmarshal(params.Arguments, &input); err != nil {
+				return mcp.CallToolResult{
+					Content: []mcp.ToolResultContent{
+						{
+							Type: "text",
+							Text: fmt.Sprintf("Failed to parse input: %s", err.Error()),
+						},
+					},
+					IsError: true,
+				}, nil
+			}
+
+			args := append(input.Options, input.Expression)
+			if len(input.Files) > 0 {
+				args = append(args, input.Files...)
+			}
+
+			s.logger.Info("Executing sed command", "expression", input.Expression, "files", input.Files, "options", input.Options)
+			cmd := exec.Command("sed", args...)
+			output, err := s.cmdExecutor.ExecuteCommand(ctx, cmd)
+
+			if err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					errorMsg := string(exitError.Stderr)
+					if errorMsg == "" {
+						errorMsg = err.Error()
+					}
+
+					s.logger.WithFields(map[string]interface{}{
+						observability.ErrorLogField: err,
+						"command":                   "sed",
+						"args":                      args,
+						"exit_code":                 exitError.ExitCode(),
+						"stderr":                    errorMsg,
+					}).Error("Sed command execution failed")
+
+					return mcp.CallToolResult{
+						Content: []mcp.ToolResultContent{
+							{
+								Type: "text",
+								Text: fmt.Sprintf("Sed command failed (exit code %d): %s\nCommand: sed %v",
+									exitError.ExitCode(), errorMsg, args),
+							},
+						},
+						IsError: true,
+					}, nil
+				}
+
+				// Handle non-exit errors
+				return mcp.CallToolResult{
+					Content: []mcp.ToolResultContent{
+						{
+							Type: "text",
+							Text: fmt.Sprintf("Command execution error: %s\nCommand: sed %v",
+								err.Error(), args),
+						},
+					},
+					IsError: true,
+				}, nil
+			}
+
+			return mcp.CallToolResult{
+				Content: []mcp.ToolResultContent{{Type: "text", Text: string(output)}},
+				IsError: false,
+			}, nil
+		},
+	}
+}


### PR DESCRIPTION
Implemented wrappers to unify the usage of grep, sed, bash, and cat commands using a consistent interface in the mcptools package. Each tool includes input schema validation, execution handling, and observability support.